### PR TITLE
Upload Kotlin android sources

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -18,6 +18,6 @@ elif [ ! -z "$CIRCLE_PULL_REQUEST" ]; then
   echo "Skipping snapshot deployment: was pull request."
 else
   echo "Deploying snapshot..."
-  ./gradlew clean uploadArchives --no-daemon --no-parallel
+  ./gradlew clean androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
   echo "Snapshot deployed!"
 fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ Releasing
  2. Update the `CHANGELOG.md` for the impending release.
  3. Update the `README.md` with the new version.
  4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version).
- 5. `./gradlew clean uploadArchives --no-daemon --no-parallel`
+ 5. `./gradlew clean androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel`
  6. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
  7. `git tag -a X.Y.X -m "X.Y.Z"` (where X.Y.Z is the new version)
  8. Update the top-level `gradle.properties` to the next SNAPSHOT version.

--- a/blueprint-interactor-common/build.gradle
+++ b/blueprint-interactor-common/build.gradle
@@ -1,19 +1,10 @@
 plugins {
     id 'kotlin'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka'
 }
 
 dependencies {
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-interactor-coroutines/build.gradle
+++ b/blueprint-interactor-coroutines/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'kotlin'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka'
 }
 
 dependencies {
-    api project(path: ':blueprint-interactor-common')
+    api project(':blueprint-interactor-common')
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
@@ -17,12 +16,4 @@ dependencies {
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.amshove.kluent:kluent:${versions.kluent}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx.coroutines}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-interactor-rx/build.gradle
+++ b/blueprint-interactor-rx/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'kotlin'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka'
 }
 
 dependencies {
-    api project(path: ':blueprint-interactor-common')
+    api project(':blueprint-interactor-common')
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
@@ -16,12 +15,4 @@ dependencies {
     // Unit tests
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.amshove.kluent:kluent:${versions.kluent}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-testing-robot/build.gradle
+++ b/blueprint-testing-robot/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka-android'
 }
 
 android {
@@ -50,13 +49,4 @@ dependencies {
     androidTestImplementation "androidx.test:rules:${versions.androidx.test.rules}"
     androidTestImplementation "androidx.test.ext:junit-ktx:${versions.androidx.test.ext.junit}"
     androidTestImplementation "org.amshove.kluent:kluent-android:${versions.kluent}"
-}
-
-afterEvaluate {
-    dokka {
-        reportUndocumented = false
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-threading-coroutines/build.gradle
+++ b/blueprint-threading-coroutines/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'kotlin'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka'
 }
 
 dependencies {
@@ -15,12 +14,4 @@ dependencies {
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.amshove.kluent:kluent:${versions.kluent}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx.coroutines}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-threading-rx/build.gradle
+++ b/blueprint-threading-rx/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'kotlin'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka'
 }
 
 dependencies {
@@ -13,12 +12,4 @@ dependencies {
 
     // Unit tests
     testImplementation "junit:junit:${versions.junit}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/blueprint-ui/build.gradle
+++ b/blueprint-ui/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.vanniktech.maven.publish'
-    id 'org.jetbrains.dokka-android'
 }
 
 android {
@@ -28,12 +27,4 @@ dependencies {
 
     // AndroidX
     implementation "androidx.appcompat:appcompat:${versions.androidx.appCompat}"
-}
-
-afterEvaluate {
-    dokka {
-        jdkVersion = 8
-        outputFormat = 'gfm'
-        outputDirectory = "$buildDir/javadoc"
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,7 @@ buildscript {
             androidGradlePlugin: '3.6.0-alpha05',
             kotlin             : '1.3.41',
             detekt             : '1.0.0-RC16',
-            mavenPublishPlugin : '0.8.0',
-            dokka              : '0.9.18',
+            mavenPublishPlugin : '0.9.0-SNAPSHOT',
             kotlinx            : [
                     coroutines: '1.3.0-RC',
             ],
@@ -53,6 +52,7 @@ buildscript {
         mavenCentral()
         google()
         gradlePluginPortal()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     dependencies {
@@ -60,8 +60,6 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
         classpath "com.vanniktech:gradle-maven-publish-plugin:${versions.mavenPublishPlugin}"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}"
     }
 }
 


### PR DESCRIPTION
- Bump gradle-maven-publish-plugin.
- Explicitly upload android sources before uploading archives.
- Remove unnecessary Dokka configs.