### PR TITLE
Maintain binary compatibility with RxJava 2 

### DIFF
--- a/blueprint-interactor-rx/build.gradle
+++ b/blueprint-interactor-rx/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
 
-    // rx
-    implementation "io.reactivex.rxjava3:rxjava:${versions.rxJava}"
+    // rx - we are binary compatible with both RxJava 2 and RxJava 3
+    compileOnly "io.reactivex.rxjava3:rxjava:${versions.rxJava3}"
 
     // Unit tests
     testImplementation "junit:junit:${versions.junit}"

--- a/blueprint-interactor-rx/build.gradle
+++ b/blueprint-interactor-rx/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id 'com.vanniktech.maven.publish'
 }
 
+sourceSets {
+    test.compileClasspath += configurations.compileOnly
+    test.runtimeClasspath += configurations.compileOnly
+}
+
 dependencies {
     api project(':blueprint-interactor-common')
 

--- a/blueprint-threading-rx/build.gradle
+++ b/blueprint-threading-rx/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id 'com.vanniktech.maven.publish'
 }
 
+sourceSets {
+    test.compileClasspath += configurations.compileOnly
+    test.runtimeClasspath += configurations.compileOnly
+}
+
 dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"

--- a/blueprint-threading-rx/build.gradle
+++ b/blueprint-threading-rx/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
 
-    // rx3
-    implementation "io.reactivex.rxjava3:rxjava:${versions.rxJava}"
+    // rx - we are binary compatible with both RxJava 2 and RxJava 3
+    compileOnly "io.reactivex.rxjava3:rxjava:${versions.rxJava3}"
 
     // Unit tests
     testImplementation "junit:junit:${versions.junit}"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             androidGradlePlugin: '3.6.0-alpha05',
             kotlin             : '1.3.41',
             detekt             : '1.0.0-RC16',
-            mavenPublishPlugin : '0.9.0-SNAPSHOT',
+            mavenPublishPlugin : '0.8.0',
             kotlinx            : [
                     coroutines: '1.3.0-RC',
             ],
@@ -53,7 +53,6 @@ buildscript {
         mavenCentral()
         google()
         gradlePluginPortal()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ buildscript {
                     espresso         : '3.3.0-alpha02'
             ],
             material           : '1.1.0-alpha08',
-            rxJava             : '3.0.0-RC1',
+            rxJava2            : '2.2.10',
+            rxJava3            : '3.0.0-RC1',
             timber             : '4.7.1',
             leakCanary         : '2.0-alpha-3',
             junit              : '4.12',


### PR DESCRIPTION
Make the RxJava3 dependencies `compileOnly` for `blueprint-interactor-rx` and `blueprint-threading-rx` libraries so users can choose which version of RxJava to use by explicitly depending on either RxJava2 or RxJava 3:

RxJava2:
```
implementation "io.reactivex.rxjava2:rxjava:2.2.10"
implementation "io.github.reactivecircus.blueprint:blueprint-interactor-rx:1.0.0"
implementation "io.github.reactivecircus.blueprint:blueprint-threading-rx:1.0.0"
``` 

RxJava3:
```
implementation "io.reactivex.rxjava3:rxjava:3.0.0"
implementation "io.github.reactivecircus.blueprint:blueprint-interactor-rx:1.0.0"
implementation "io.github.reactivecircus.blueprint:blueprint-threading-rx:1.0.0"
``` 

Both `blueprint-interactor-rx` and `blueprint-threading-rx` use very small sets of **RxJava 3** API surfaces so as long as those APIs remain binary compatible with **RxJava 2**, we don't need to publish 2 separate sets of artifacts to support both RxJava 2 and RxJava 3 users.