### PR TITLE
Add RobotAction for clicking on Snackbar Action Button

### DIFF
--- a/blueprint-testing-robot/src/main/kotlin/reactivecircus/blueprint/testing/action/SnackbarRobotActions.kt
+++ b/blueprint-testing-robot/src/main/kotlin/reactivecircus/blueprint/testing/action/SnackbarRobotActions.kt
@@ -1,0 +1,14 @@
+package reactivecircus.blueprint.testing.action
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import reactivecircus.blueprint.testing.R
+import reactivecircus.blueprint.testing.RobotActions
+
+/**
+ * Click the action button on the currently displayed Snackbar.
+ */
+fun RobotActions.clickSnackbarActionButton() {
+    Espresso.onView(ViewMatchers.withId(R.id.snackbar_action)).perform(ViewActions.click())
+}


### PR DESCRIPTION
`blueprint-testing-robot`: added RobotAction for clicking on the action button on the currently displayed snackbar.