### PR TITLE
RxJava 3 RC2

### DIFF
--- a/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/CompletableInteractor.kt
+++ b/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/CompletableInteractor.kt
@@ -1,7 +1,7 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Completable
-import io.reactivex.Scheduler
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Scheduler
 import reactivecircus.blueprint.interactor.InteractorParams
 
 /**

--- a/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/ObservableInteractor.kt
+++ b/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/ObservableInteractor.kt
@@ -1,7 +1,7 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Observable
-import io.reactivex.Scheduler
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Scheduler
 import reactivecircus.blueprint.interactor.InteractorParams
 
 /**

--- a/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/SingleInteractor.kt
+++ b/blueprint-interactor-rx3/src/main/kotlin/reactivecircus/blueprint/interactor/rx3/SingleInteractor.kt
@@ -1,7 +1,7 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Scheduler
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.core.Single
 import reactivecircus.blueprint.interactor.InteractorParams
 
 /**

--- a/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/CompletableInteractorTest.kt
+++ b/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/CompletableInteractorTest.kt
@@ -1,9 +1,9 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Completable
-import io.reactivex.Scheduler
-import io.reactivex.observers.TestObserver
-import io.reactivex.schedulers.TestScheduler
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.observers.TestObserver
+import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.Test
 import reactivecircus.blueprint.interactor.EmptyParams
 import reactivecircus.blueprint.interactor.InteractorParams

--- a/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/ObservableInteractorTest.kt
+++ b/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/ObservableInteractorTest.kt
@@ -1,9 +1,9 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Observable
-import io.reactivex.Scheduler
-import io.reactivex.observers.TestObserver
-import io.reactivex.schedulers.TestScheduler
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.observers.TestObserver
+import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.Test
 import reactivecircus.blueprint.interactor.EmptyParams
 import reactivecircus.blueprint.interactor.InteractorParams

--- a/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/SingleInteractorTest.kt
+++ b/blueprint-interactor-rx3/src/test/kotlin/reactivecircus/blueprint/interactor/rx3/SingleInteractorTest.kt
@@ -1,9 +1,9 @@
 package reactivecircus.blueprint.interactor.rx3
 
-import io.reactivex.Scheduler
-import io.reactivex.Single
-import io.reactivex.observers.TestObserver
-import io.reactivex.schedulers.TestScheduler
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.observers.TestObserver
+import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.Test
 import reactivecircus.blueprint.interactor.EmptyParams
 import reactivecircus.blueprint.interactor.InteractorParams

--- a/blueprint-threading-rx3/src/main/kotlin/reactivecircus/blueprint/threading/rx3/SchedulerProvider.kt
+++ b/blueprint-threading-rx3/src/main/kotlin/reactivecircus/blueprint/threading/rx3/SchedulerProvider.kt
@@ -1,6 +1,6 @@
 package reactivecircus.blueprint.threading.rx3
 
-import io.reactivex.Scheduler
+import io.reactivex.rxjava3.core.Scheduler
 
 /**
  * A wrapper class for common Rx schedulers.

--- a/blueprint-threading-rx3/src/test/kotlin/reactivecircus/blueprint/threading/rx3/SchedulerProviderTest.kt
+++ b/blueprint-threading-rx3/src/test/kotlin/reactivecircus/blueprint/threading/rx3/SchedulerProviderTest.kt
@@ -1,7 +1,7 @@
 package reactivecircus.blueprint.threading.rx3
 
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 import org.junit.Test
 
 class SchedulerProviderTest {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
             ],
             material           : '1.1.0-alpha09',
             rxJava2            : '2.2.11',
-            rxJava3            : '3.0.0-RC1',
+            rxJava3            : '3.0.0-RC2',
             rxKotlin           : '2.3.0',
             rxAndroid          : '2.1.1',
             timber             : '4.7.1',


### PR DESCRIPTION
RxJava 3 RC2 changed its base package to include `rxjava3`. This is a breaking change but effectively affects 0 user.