### PR TITLE
Coroutines to 1.3.6 and StateFlow

### DIFF
--- a/blueprint-interactor-coroutines/src/main/kotlin/reactivecircus/blueprint/interactor/coroutines/FlowInteractor.kt
+++ b/blueprint-interactor-coroutines/src/main/kotlin/reactivecircus/blueprint/interactor/coroutines/FlowInteractor.kt
@@ -1,7 +1,6 @@
 package reactivecircus.blueprint.interactor.coroutines
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import reactivecircus.blueprint.interactor.InteractorParams
@@ -27,6 +26,5 @@ abstract class FlowInteractor<in P : InteractorParams, out R> {
     /**
      * Build a new [Flow] from this interactor.
      */
-    @ExperimentalCoroutinesApi
     fun buildFlow(params: P): Flow<R> = createFlow(params).flowOn(dispatcher)
 }

--- a/buildSrc/dependencies.gradle
+++ b/buildSrc/dependencies.gradle
@@ -7,7 +7,7 @@ rootProject.ext.versions = [
         detekt                      : '1.8.0',
         leakCanary                  : '2.3',
         kotlinx                     : [
-                coroutines: '1.3.5',
+                coroutines: '1.3.6',
         ],
         androidx                    : [
                 core             : '1.3.0-rc01',

--- a/samples/README.md
+++ b/samples/README.md
@@ -76,7 +76,7 @@ A number of important things are left out as our focus here is how the **Bluepri
 
 * We implemented a **very** simple Dependency Injection (Service Locator to be precise) framework. Consider using [Dagger][dagger] or [Koin][koin] in a real project.
 * Different layers (e.g. **domain**, **data**, **presentation**) should probably live in their own modules in a real project.
-* Both samples use AndroidX `ViewModel` and `LiveData` in the presentation layer. For better managing complex states you might want to consider using a redux-based architecture that employs **Uni-directional Data Flow**. I personally recommend [RxRedux][rxredux] and its Coroutines-based equivalent.
+* Both samples use AndroidX `ViewModel` in the presentation layer. For better managing complex states you might want to consider using a redux-based architecture that employs **Uni-directional Data Flow**. I personally recommend [RxRedux][rxredux] and its Coroutines-based equivalent.
 * In a real project you will want to set up **product flavors** for different environments (e.g. mock, staging, production).
 * Obviously the apps don't talk to any backend APIs and lack persistent storage.
 

--- a/samples/demo-common/src/main/kotlin/reactivecircus/blueprint/demo/data/cache/InMemoryNoteCache.kt
+++ b/samples/demo-common/src/main/kotlin/reactivecircus/blueprint/demo/data/cache/InMemoryNoteCache.kt
@@ -10,7 +10,7 @@ class InMemoryNoteCache : NoteCache {
     private val notes = mutableListOf<Note>()
 
     override fun allNotes(): List<Note> {
-        return notes
+        return notes.toList()
     }
 
     override fun findNote(criteria: (Note) -> Boolean): Note? {

--- a/samples/demo-coroutines/build.gradle
+++ b/samples/demo-coroutines/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:${versions.androidx.recyclerView}"
     implementation "androidx.core:core-ktx:${versions.androidx.core}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.androidx.lifecycle}"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:${versions.androidx.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-common-java8:${versions.androidx.lifecycle}"
     implementation "androidx.arch.core:core-runtime:${versions.androidx.arch}"
 

--- a/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesBaseScreenTest.kt
+++ b/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesBaseScreenTest.kt
@@ -7,12 +7,10 @@ import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.intent.Intents
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.After
 import org.junit.Before
 import reactivecircus.blueprint.demo.data.cache.NoteCache
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 abstract class CoroutinesBaseScreenTest {
 

--- a/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesScreenTestApp.kt
+++ b/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesScreenTestApp.kt
@@ -1,11 +1,9 @@
 package reactivecircus.blueprint.demo
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 class CoroutinesScreenTestApp : BlueprintCoroutinesDemoApp() {
 
-    @FlowPreview
     @ExperimentalCoroutinesApi
     override val injector: CoroutinesAppInjector = CoroutinesScreenTestAppInjector()
 }

--- a/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesScreenTestAppInjector.kt
+++ b/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/CoroutinesScreenTestAppInjector.kt
@@ -3,11 +3,9 @@ package reactivecircus.blueprint.demo
 import android.os.AsyncTask
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.asCoroutineDispatcher
 import reactivecircus.blueprint.async.coroutines.CoroutineDispatcherProvider
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 class CoroutinesScreenTestAppInjector : CoroutinesAppInjector() {
 

--- a/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/enternote/CoroutinesEnterNoteScreenTest.kt
+++ b/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/enternote/CoroutinesEnterNoteScreenTest.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.LargeTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import reactivecircus.blueprint.demo.CoroutinesBaseScreenTest
 import reactivecircus.blueprint.demo.noteslist.CoroutinesNotesListActivity
@@ -13,7 +12,6 @@ import reactivecircus.blueprint.demo.testNotes
 import reactivecircus.blueprint.testing.action.clickNavigateUpButton
 import reactivecircus.blueprint.ui.extension.newIntent
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 @LargeTest
 class CoroutinesEnterNoteScreenTest : CoroutinesBaseScreenTest() {

--- a/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/noteslist/CoroutinesNotesListScreenTest.kt
+++ b/samples/demo-coroutines/src/androidTest/kotlin/reactivecircus/blueprint/demo/noteslist/CoroutinesNotesListScreenTest.kt
@@ -2,14 +2,12 @@ package reactivecircus.blueprint.demo.noteslist
 
 import androidx.test.filters.LargeTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import reactivecircus.blueprint.demo.CoroutinesBaseScreenTest
 import reactivecircus.blueprint.demo.enternote.CoroutinesEnterNoteActivity
 import reactivecircus.blueprint.demo.testNotes
 import reactivecircus.blueprint.testing.assertion.activityLaunched
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 @LargeTest
 class CoroutinesNotesListScreenTest : CoroutinesBaseScreenTest() {

--- a/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/BlueprintCoroutinesDemoApp.kt
+++ b/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/BlueprintCoroutinesDemoApp.kt
@@ -2,7 +2,6 @@ package reactivecircus.blueprint.demo
 
 import android.app.Application
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import timber.log.Timber
 
 open class BlueprintCoroutinesDemoApp : Application() {
@@ -12,7 +11,6 @@ open class BlueprintCoroutinesDemoApp : Application() {
         Timber.plant(Timber.DebugTree())
     }
 
-    @FlowPreview
     @ExperimentalCoroutinesApi
     open val injector: CoroutinesAppInjector = CoroutinesAppInjector()
 }

--- a/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/CoroutinesAppInjector.kt
+++ b/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/CoroutinesAppInjector.kt
@@ -2,7 +2,7 @@ package reactivecircus.blueprint.demo
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import reactivecircus.blueprint.async.coroutines.CoroutineDispatcherProvider
 import reactivecircus.blueprint.demo.data.cache.InMemoryNoteCache
 import reactivecircus.blueprint.demo.data.cache.NoteCache
 import reactivecircus.blueprint.demo.data.repository.CoroutinesInMemoryNoteRepository
@@ -13,9 +13,7 @@ import reactivecircus.blueprint.demo.domain.interactor.CoroutinesUpdateNote
 import reactivecircus.blueprint.demo.domain.repository.CoroutinesNoteRepository
 import reactivecircus.blueprint.demo.enternote.CoroutinesEnterNoteViewModel
 import reactivecircus.blueprint.demo.noteslist.CoroutinesNotesListViewModel
-import reactivecircus.blueprint.async.coroutines.CoroutineDispatcherProvider
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 open class CoroutinesAppInjector {
 

--- a/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/data/repository/CoroutinesInMemoryNoteRepository.kt
+++ b/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/data/repository/CoroutinesInMemoryNoteRepository.kt
@@ -3,10 +3,11 @@ package reactivecircus.blueprint.demo.data.repository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import reactivecircus.blueprint.demo.data.cache.NoteCache
 import reactivecircus.blueprint.demo.domain.model.Note
 import reactivecircus.blueprint.demo.domain.repository.CoroutinesNoteRepository
@@ -17,11 +18,12 @@ class CoroutinesInMemoryNoteRepository(
     private val noteCache: NoteCache
 ) : CoroutinesNoteRepository {
 
-    private val notesBroadcastChannel: BroadcastChannel<Unit> = ConflatedBroadcastChannel(Unit)
+    private val notesChannel: BroadcastChannel<Unit> = BroadcastChannel(BUFFERED)
 
     override fun streamAllNotes(): Flow<List<Note>> {
-        return notesBroadcastChannel.asFlow()
+        return notesChannel.asFlow()
             .map { noteCache.allNotes() }
+            .onStart { emit(noteCache.allNotes()) }
     }
 
     override suspend fun getNoteByUuid(uuid: String): Note? {
@@ -32,13 +34,13 @@ class CoroutinesInMemoryNoteRepository(
         noteCache.addNotes(listOf(note))
 
         // refresh all notes stream
-        notesBroadcastChannel.offer(Unit)
+        notesChannel.offer(Unit)
     }
 
     override suspend fun updateNote(note: Note) {
         noteCache.updateNote(note)
 
         // refresh all notes stream
-        notesBroadcastChannel.offer(Unit)
+        notesChannel.offer(Unit)
     }
 }

--- a/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/noteslist/CoroutinesNotesListViewModel.kt
+++ b/samples/demo-coroutines/src/main/kotlin/reactivecircus/blueprint/demo/noteslist/CoroutinesNotesListViewModel.kt
@@ -1,14 +1,14 @@
 package reactivecircus.blueprint.demo.noteslist
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import reactivecircus.blueprint.demo.domain.interactor.CoroutinesStreamAllNotes
 import reactivecircus.blueprint.demo.domain.model.Note
 import timber.log.Timber
@@ -23,16 +23,15 @@ class CoroutinesNotesListViewModel(
     streamAllNotes: CoroutinesStreamAllNotes
 ) : ViewModel() {
 
-    val notesLiveData = MutableLiveData<State>()
+    private val notesStateFlow = MutableStateFlow<State>(State.LoadingNotes)
+
+    val notesFlow: Flow<State> = notesStateFlow
 
     init {
         streamAllNotes.buildFlow(CoroutinesStreamAllNotes.Params(CoroutinesStreamAllNotes.SortedBy.TIME_LAST_UPDATED))
             .map { State.Idle(it) }
-            .onStart<State> {
-                emit(State.LoadingNotes)
-            }
             .onEach {
-                notesLiveData.value = it
+                notesStateFlow.value = it
             }
             .catch {
                 Timber.e(it)

--- a/samples/demo-coroutines/src/test/kotlin/reactivecircus/blueprint/demo/domain/interactor/CoroutinesStreamAllNotesTest.kt
+++ b/samples/demo-coroutines/src/test/kotlin/reactivecircus/blueprint/demo/domain/interactor/CoroutinesStreamAllNotesTest.kt
@@ -4,15 +4,15 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldEqual
 import org.junit.Test
+import reactivecircus.blueprint.async.coroutines.CoroutineDispatcherProvider
 import reactivecircus.blueprint.demo.domain.model.Note
 import reactivecircus.blueprint.demo.domain.repository.CoroutinesNoteRepository
-import reactivecircus.blueprint.async.coroutines.CoroutineDispatcherProvider
 
 @ExperimentalCoroutinesApi
 class CoroutinesStreamAllNotesTest {
@@ -34,7 +34,7 @@ class CoroutinesStreamAllNotesTest {
 
         val result = streamAllNotes.buildFlow(
             CoroutinesStreamAllNotes.Params(CoroutinesStreamAllNotes.SortedBy.TIME_CREATED)
-        ).single()
+        ).first()
 
         verify(exactly = 1) {
             noteRepository.streamAllNotes()
@@ -63,7 +63,7 @@ class CoroutinesStreamAllNotesTest {
 
         val result = streamAllNotes.buildFlow(
             CoroutinesStreamAllNotes.Params(CoroutinesStreamAllNotes.SortedBy.TIME_CREATED)
-        ).single()
+        ).first()
 
         verify(exactly = 1) {
             noteRepository.streamAllNotes()
@@ -92,7 +92,7 @@ class CoroutinesStreamAllNotesTest {
 
         val result = streamAllNotes.buildFlow(
             CoroutinesStreamAllNotes.Params(CoroutinesStreamAllNotes.SortedBy.TIME_LAST_UPDATED)
-        ).single()
+        ).first()
 
         verify(exactly = 1) {
             noteRepository.streamAllNotes()

--- a/samples/demo-rx/README.md
+++ b/samples/demo-rx/README.md
@@ -25,7 +25,7 @@ class RxGetNoteByUuid(
     override fun createInteractor(params: Params): Single<Note> {
         return noteRepository.getNoteByUuid(params.uuid)
             .switchIfEmpty(
-                Maybe.error<Note>(IllegalStateException("Could not find note by uuid."))
+                Maybe.error(IllegalStateException("Could not find note by uuid."))
             )
             .toSingle()
     }

--- a/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/domain/interactor/RxGetNoteByUuid.kt
+++ b/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/domain/interactor/RxGetNoteByUuid.kt
@@ -18,7 +18,7 @@ class RxGetNoteByUuid(
     override fun createInteractor(params: Params): Single<Note> {
         return noteRepository.getNoteByUuid(params.uuid)
             .switchIfEmpty(
-                Maybe.error<Note>(IllegalStateException("Could not find note by uuid."))
+                Maybe.error(IllegalStateException("Could not find note by uuid."))
             )
             .toSingle()
     }

--- a/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/enternote/RxEnterNoteViewModel.kt
+++ b/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/enternote/RxEnterNoteViewModel.kt
@@ -1,5 +1,6 @@
 package reactivecircus.blueprint.demo.enternote
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -20,7 +21,9 @@ class RxEnterNoteViewModel(
     private val updateNote: RxUpdateNote
 ) : ViewModel() {
 
-    val noteLiveData = MutableLiveData<State>()
+    private val mutableNoteLiveData = MutableLiveData<State>()
+
+    val noteLiveData: LiveData<State> = mutableNoteLiveData
 
     private val disposable = CompositeDisposable()
 
@@ -29,14 +32,14 @@ class RxEnterNoteViewModel(
             disposable += getNoteByUuid.buildSingle(RxGetNoteByUuid.Params(noteUuid))
                 .subscribeBy(
                     onSuccess = { note ->
-                        noteLiveData.value = State(note)
+                        mutableNoteLiveData.value = State(note)
                     },
                     onError = {
                         Timber.e(it)
                     }
                 )
         } else {
-            noteLiveData.value = State(null)
+            mutableNoteLiveData.value = State(null)
         }
     }
 

--- a/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/noteslist/RxNotesListViewModel.kt
+++ b/samples/demo-rx/src/main/kotlin/reactivecircus/blueprint/demo/noteslist/RxNotesListViewModel.kt
@@ -1,5 +1,6 @@
 package reactivecircus.blueprint.demo.noteslist
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -18,7 +19,9 @@ class RxNotesListViewModel(
     streamAllNotes: RxStreamAllNotes
 ) : ViewModel() {
 
-    val notesLiveData = MutableLiveData<State>()
+    private val mutableNotesLiveData = MutableLiveData<State>()
+
+    val notesLiveData: LiveData<State> = mutableNotesLiveData
 
     private val disposable = CompositeDisposable()
 
@@ -31,7 +34,7 @@ class RxNotesListViewModel(
             .startWithItem(State.LoadingNotes)
             .subscribeBy(
                 onNext = {
-                    notesLiveData.value = it
+                    mutableNotesLiveData.value = it
                 },
                 onError = {
                     Timber.e(it)


### PR DESCRIPTION
- Update Coroutines to 1.3.6
- Migrate coroutines sample to use `StateFlow` instead of `LiveData`